### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/amplify/backend/auth/userPoolGroups/template.json
+++ b/amplify/backend/auth/userPoolGroups/template.json
@@ -246,7 +246,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs12.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": 300,
                 "Role": {
                     "Fn::GetAtt": [

--- a/amplify/backend/function/ConnectDialerJS/ConnectDialerJS-cloudformation-template.json
+++ b/amplify/backend/function/ConnectDialerJS/ConnectDialerJS-cloudformation-template.json
@@ -147,7 +147,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": "25",
         "Code": {
           "S3Bucket": {

--- a/amplify/backend/function/ConnectDialerSuccessUpdateJS/ConnectDialerSuccessUpdateJS-cloudformation-template.json
+++ b/amplify/backend/function/ConnectDialerSuccessUpdateJS/ConnectDialerSuccessUpdateJS-cloudformation-template.json
@@ -79,7 +79,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": "25",
         "Code": {
           "S3Bucket": {

--- a/amplify/backend/function/apiRESTtelephonenumber/apiRESTtelephonenumber-cloudformation-template.json
+++ b/amplify/backend/function/apiRESTtelephonenumber/apiRESTtelephonenumber-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": "25",
         "Code": {
           "S3Bucket": {

--- a/amplify/backend/function/csvUploadStoreTrigger/csvUploadStoreTrigger-cloudformation-template.json
+++ b/amplify/backend/function/csvUploadStoreTrigger/csvUploadStoreTrigger-cloudformation-template.json
@@ -91,7 +91,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": "25",
         "Code": {
           "S3Bucket": {


### PR DESCRIPTION
CloudFormation templates in aws-amplify-connect have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.